### PR TITLE
Phase 4: Draft表示インターフェース実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,45 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter, Link, useLocation } from 'react-router-dom'
 import { AuthProvider } from '@/components/auth/AuthProvider'
 import AppRoutes from './routes'
+
+function Navigation() {
+  const location = useLocation()
+
+  return (
+    <nav className="bg-gray-800 text-white p-4 flex gap-4">
+      <Link
+        to="/"
+        className={`px-4 py-2 rounded transition-colors ${
+          location.pathname === '/' ? 'bg-gray-600' : 'hover:bg-gray-700'
+        }`}
+      >
+        Chat
+      </Link>
+      <Link
+        to="/drafts"
+        className={`px-4 py-2 rounded transition-colors ${
+          location.pathname === '/drafts' ? 'bg-gray-600' : 'hover:bg-gray-700'
+        }`}
+      >
+        Drafts
+      </Link>
+    </nav>
+  )
+}
 
 export default function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <AppRoutes />
+        <div className="flex flex-col h-screen">
+          <Navigation />
+          <div className="flex-1 overflow-hidden">
+            <AppRoutes />
+          </div>
+        </div>
       </AuthProvider>
     </BrowserRouter>
   )

--- a/frontend/src/components/drafts/DraftDetail.tsx
+++ b/frontend/src/components/drafts/DraftDetail.tsx
@@ -1,0 +1,112 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { MarkdownRenderer } from "@/components/chat/MarkdownRenderer"
+import { DraftDetail as DraftDetailType } from "@/services/draftsService"
+
+interface DraftDetailProps {
+  draftDetail: DraftDetailType | null
+  isLoading: boolean
+  error: string | null
+}
+
+export function DraftDetail({ draftDetail, isLoading, error }: DraftDetailProps) {
+  if (isLoading) {
+    return (
+      <div className="p-4 space-y-4">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <p className="text-red-500">{error}</p>
+      </div>
+    )
+  }
+
+  if (!draftDetail) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-gray-500">Select a draft to view details</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-2">{draftDetail.date}</h1>
+      <p className="text-sm text-gray-500 mb-4">
+        Extracted: {new Date(draftDetail.metadata.extracted_at).toLocaleString()}
+      </p>
+
+      <Tabs defaultValue="original" className="w-full">
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="original">Original Diary</TabsTrigger>
+          <TabsTrigger value="references">References</TabsTrigger>
+          <TabsTrigger value="ideas">Ideas</TabsTrigger>
+          <TabsTrigger value="goals">Goals</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="original">
+          <Card>
+            <CardHeader>
+              <CardTitle>Original Diary</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <MarkdownRenderer content={draftDetail.original} />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="references">
+          <Card>
+            <CardHeader>
+              <CardTitle>References</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {draftDetail.references ? (
+                <MarkdownRenderer content={draftDetail.references} />
+              ) : (
+                <p className="text-gray-500">No references</p>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="ideas">
+          <Card>
+            <CardHeader>
+              <CardTitle>Ideas</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {draftDetail.ideas ? (
+                <MarkdownRenderer content={draftDetail.ideas} />
+              ) : (
+                <p className="text-gray-500">No ideas</p>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="goals">
+          <Card>
+            <CardHeader>
+              <CardTitle>Goals</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {draftDetail.goals ? (
+                <MarkdownRenderer content={draftDetail.goals} />
+              ) : (
+                <p className="text-gray-500">No goals</p>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/frontend/src/components/drafts/DraftsList.tsx
+++ b/frontend/src/components/drafts/DraftsList.tsx
@@ -1,0 +1,68 @@
+import { Card } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Draft } from "@/services/draftsService"
+
+interface DraftsListProps {
+  drafts: Draft[]
+  selectedDate: string | null
+  onSelectDate: (date: string) => void
+  isLoading: boolean
+  error: string | null
+}
+
+export function DraftsList({
+  drafts,
+  selectedDate,
+  onSelectDate,
+  isLoading,
+  error,
+}: DraftsListProps) {
+  if (isLoading) {
+    return (
+      <div className="p-4 space-y-2">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Skeleton key={i} className="h-20 w-full" />
+        ))}
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <p className="text-red-500">{error}</p>
+      </div>
+    )
+  }
+
+  if (drafts.length === 0) {
+    return (
+      <div className="p-4">
+        <p className="text-gray-500">No drafts found</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 space-y-2">
+      <h2 className="text-xl font-bold mb-4">Draft List</h2>
+      {drafts.map((draft) => (
+        <Card
+          key={draft.date}
+          className={`p-4 cursor-pointer hover:bg-gray-50 transition-colors ${
+            selectedDate === draft.date ? "border-blue-500 border-2 bg-blue-50" : ""
+          }`}
+          onClick={() => onSelectDate(draft.date)}
+        >
+          <div className="font-semibold text-lg">{draft.date}</div>
+          <div className="text-sm text-gray-500 mt-1">
+            Extracted: {new Date(draft.extracted_at).toLocaleString()}
+          </div>
+          <div className="text-xs text-gray-400 mt-1">
+            Status: {draft.status}
+          </div>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/frontend/src/routes/ChatPage.tsx
+++ b/frontend/src/routes/ChatPage.tsx
@@ -21,7 +21,7 @@ export default function ChatPage() {
 
   return (
     <GlobalContextProvider>
-      <div className="relative h-screen">
+      <div className="relative h-full">
         <ChatInterface />
       </div>
     </GlobalContextProvider>

--- a/frontend/src/routes/DraftsPage.tsx
+++ b/frontend/src/routes/DraftsPage.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useAuth } from "@/hooks/useAuth"
+import { Button } from "@/components/ui/button"
+import { DraftsList } from "@/components/drafts/DraftsList"
+import { DraftDetail } from "@/components/drafts/DraftDetail"
+import {
+  getDrafts,
+  getDraftDetail,
+  Draft,
+  DraftDetail as DraftDetailType,
+} from "@/services/draftsService"
+
+export default function DraftsPage() {
+  const { isAuthenticated, signIn, user } = useAuth()
+  const [drafts, setDrafts] = useState<Draft[]>([])
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [draftDetail, setDraftDetail] = useState<DraftDetailType | null>(null)
+  const [isLoadingList, setIsLoadingList] = useState(false)
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (!isAuthenticated) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+        <p className="text-4xl">Please sign in</p>
+        <Button onClick={() => signIn()}>Sign In</Button>
+      </div>
+    )
+  }
+
+  useEffect(() => {
+    async function loadDrafts() {
+      setIsLoadingList(true)
+      setError(null)
+      try {
+        const idToken = user?.id_token
+        if (!idToken) throw new Error("No ID token")
+
+        const data = await getDrafts(idToken)
+        setDrafts(data.drafts)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load drafts")
+      } finally {
+        setIsLoadingList(false)
+      }
+    }
+    loadDrafts()
+  }, [user])
+
+  useEffect(() => {
+    async function loadDetail() {
+      if (!selectedDate) {
+        setDraftDetail(null)
+        return
+      }
+
+      setIsLoadingDetail(true)
+      setError(null)
+      try {
+        const idToken = user?.id_token
+        if (!idToken) throw new Error("No ID token")
+
+        const data = await getDraftDetail(selectedDate, idToken)
+        setDraftDetail(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load draft detail")
+      } finally {
+        setIsLoadingDetail(false)
+      }
+    }
+    loadDetail()
+  }, [selectedDate, user])
+
+  return (
+    <div className="flex h-full">
+      <div className="w-1/3 border-r overflow-y-auto">
+        <DraftsList
+          drafts={drafts}
+          selectedDate={selectedDate}
+          onSelectDate={setSelectedDate}
+          isLoading={isLoadingList}
+          error={error}
+        />
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <DraftDetail
+          draftDetail={draftDetail}
+          isLoading={isLoadingDetail}
+          error={error}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -3,11 +3,13 @@
 
 import { Routes, Route } from 'react-router-dom'
 import ChatPage from './ChatPage'
+import DraftsPage from './DraftsPage'
 
 export default function AppRoutes() {
   return (
     <Routes>
       <Route path="/" element={<ChatPage />} />
+      <Route path="/drafts" element={<DraftsPage />} />
     </Routes>
   )
 }

--- a/frontend/src/services/draftsService.ts
+++ b/frontend/src/services/draftsService.ts
@@ -1,0 +1,124 @@
+/**
+ * Drafts Service
+ * Handles fetching draft diary extractions from the backend API
+ */
+
+// Load API URL from aws-exports.json
+let DRAFTS_API_URL = ""
+
+// Dynamically load the API URL from aws-exports.json
+async function loadApiUrl(): Promise<string> {
+  if (DRAFTS_API_URL) {
+    return DRAFTS_API_URL
+  }
+
+  try {
+    const response = await fetch("/aws-exports.json")
+    const config = await response.json()
+    DRAFTS_API_URL = config.feedbackApiUrl ? `${config.feedbackApiUrl}drafts` : ""
+    return DRAFTS_API_URL
+  } catch (error) {
+    console.error("Failed to load API URL from aws-exports.json:", error)
+    throw new Error("Drafts API URL not configured")
+  }
+}
+
+export interface Draft {
+  date: string
+  extracted_at: string
+  status: string
+}
+
+export interface DraftDetail {
+  date: string
+  metadata: {
+    extracted_at: string
+    model_id: string
+    extraction_status: string
+  }
+  original: string
+  references: string
+  ideas: string
+  goals: string
+}
+
+export interface DraftsListResponse {
+  drafts: Draft[]
+}
+
+/**
+ * Get list of drafts
+ *
+ * @param idToken - Cognito ID token for authentication
+ * @param dateFrom - Optional start date filter (YYYY-MM-DD)
+ * @param dateTo - Optional end date filter (YYYY-MM-DD)
+ * @returns Promise with list of drafts
+ */
+export async function getDrafts(
+  idToken: string,
+  dateFrom?: string,
+  dateTo?: string
+): Promise<DraftsListResponse> {
+  try {
+    const apiUrl = await loadApiUrl()
+
+    const params = new URLSearchParams()
+    if (dateFrom) params.append("date_from", dateFrom)
+    if (dateTo) params.append("date_to", dateTo)
+
+    const url = `${apiUrl}${params.toString() ? `?${params.toString()}` : ""}`
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${idToken}`,
+      },
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(errorData.error || `HTTP error! status: ${response.status}`)
+    }
+
+    const data: DraftsListResponse = await response.json()
+    return data
+  } catch (error) {
+    console.error("Error fetching drafts:", error)
+    throw error
+  }
+}
+
+/**
+ * Get draft detail for a specific date
+ *
+ * @param date - Date string in YYYY-MM-DD format
+ * @param idToken - Cognito ID token for authentication
+ * @returns Promise with draft detail
+ */
+export async function getDraftDetail(
+  date: string,
+  idToken: string
+): Promise<DraftDetail> {
+  try {
+    const apiUrl = await loadApiUrl()
+    const url = `${apiUrl}/${date}`
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${idToken}`,
+      },
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(errorData.error || `HTTP error! status: ${response.status}`)
+    }
+
+    const data: DraftDetail = await response.json()
+    return data
+  } catch (error) {
+    console.error("Error fetching draft detail:", error)
+    throw error
+  }
+}

--- a/infra-cdk/lambdas/drafts/index.py
+++ b/infra-cdk/lambdas/drafts/index.py
@@ -1,0 +1,239 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drafts API Lambda Handler"""
+
+import json
+import os
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import boto3
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver, CORSConfig
+from aws_lambda_powertools.logging.correlation_paths import API_GATEWAY_REST
+from aws_lambda_powertools.utilities.typing import LambdaContext
+from botocore.exceptions import ClientError
+
+# Environment variables
+S3_BUCKET_NAME = os.environ["S3_BUCKET_NAME"]
+CORS_ALLOWED_ORIGINS = os.environ.get("CORS_ALLOWED_ORIGINS", "*")
+
+# Parse CORS origins - can be comma-separated list
+cors_origins = [
+    origin.strip() for origin in CORS_ALLOWED_ORIGINS.split(",") if origin.strip()
+]
+primary_origin = cors_origins[0] if cors_origins else "*"
+extra_origins = cors_origins[1:] if len(cors_origins) > 1 else None
+
+# Configure CORS
+cors_config = CORSConfig(
+    allow_origin=primary_origin,
+    extra_origins=extra_origins,
+    allow_headers=["Content-Type", "Authorization"],
+    allow_credentials=True,
+)
+
+# Initialize S3 client
+s3_client = boto3.client("s3")
+
+tracer = Tracer()
+logger = Logger()
+app = APIGatewayRestResolver(cors=cors_config)
+
+
+def get_draft_dates(date_from: Optional[str] = None, date_to: Optional[str] = None) -> List[str]:
+    """
+    Get list of draft dates from S3.
+
+    Args:
+        date_from: Start date filter (YYYY-MM-DD)
+        date_to: End date filter (YYYY-MM-DD)
+
+    Returns:
+        List of date strings in YYYY-MM-DD format
+    """
+    try:
+        response = s3_client.list_objects_v2(
+            Bucket=S3_BUCKET_NAME,
+            Prefix="draft/",
+            Delimiter="/"
+        )
+
+        if "CommonPrefixes" not in response:
+            return []
+
+        dates = []
+        for prefix in response["CommonPrefixes"]:
+            # Extract date from "draft/YYYY-MM-DD/"
+            date_str = prefix["Prefix"].replace("draft/", "").replace("/", "")
+
+            if not date_str:
+                continue
+
+            # Apply date filters
+            if date_from and date_str < date_from:
+                continue
+            if date_to and date_str > date_to:
+                continue
+
+            dates.append(date_str)
+
+        return sorted(dates, reverse=True)  # Most recent first
+
+    except ClientError as e:
+        logger.error(f"S3 error listing drafts: {e}")
+        raise
+
+
+def get_draft_metadata(date: str) -> Optional[Dict[str, Any]]:
+    """
+    Get metadata for a specific draft.
+
+    Args:
+        date: Date string in YYYY-MM-DD format
+
+    Returns:
+        Metadata dictionary or None if not found
+    """
+    try:
+        response = s3_client.get_object(
+            Bucket=S3_BUCKET_NAME,
+            Key=f"draft/{date}/metadata.json"
+        )
+        content = response["Body"].read().decode("utf-8")
+        return json.loads(content)
+
+    except s3_client.exceptions.NoSuchKey:
+        return None
+    except ClientError as e:
+        logger.error(f"S3 error getting metadata for {date}: {e}")
+        raise
+
+
+def get_draft_file(date: str, filename: str) -> Optional[str]:
+    """
+    Get content of a draft file.
+
+    Args:
+        date: Date string in YYYY-MM-DD format
+        filename: File name (e.g., "original.md", "references.md")
+
+    Returns:
+        File content or None if not found
+    """
+    try:
+        response = s3_client.get_object(
+            Bucket=S3_BUCKET_NAME,
+            Key=f"draft/{date}/{filename}"
+        )
+        return response["Body"].read().decode("utf-8")
+
+    except s3_client.exceptions.NoSuchKey:
+        return None
+    except ClientError as e:
+        logger.error(f"S3 error getting {filename} for {date}: {e}")
+        raise
+
+
+@app.get("/drafts")
+@tracer.capture_method
+def list_drafts() -> Dict[str, Any]:
+    """
+    Handle GET /drafts endpoint.
+
+    Query Parameters:
+        date_from: Start date filter (YYYY-MM-DD)
+        date_to: End date filter (YYYY-MM-DD)
+
+    Returns:
+        Response with list of drafts
+    """
+    try:
+        # Get query parameters
+        date_from = app.current_event.get_query_string_value("date_from")
+        date_to = app.current_event.get_query_string_value("date_to")
+
+        # Get draft dates
+        dates = get_draft_dates(date_from, date_to)
+
+        # Get metadata for each date
+        drafts = []
+        for date in dates:
+            metadata = get_draft_metadata(date)
+            if metadata:
+                drafts.append({
+                    "date": date,
+                    "extracted_at": metadata.get("extracted_at"),
+                    "status": metadata.get("extraction_status", "unknown")
+                })
+
+        return {"drafts": drafts}
+
+    except ClientError as e:
+        logger.error(f"Error listing drafts: {e}")
+        return {"error": "Internal server error"}, 500
+
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+        return {"error": "Internal server error"}, 500
+
+
+@app.get("/drafts/<date>")
+@tracer.capture_method
+def get_draft_detail(date: str) -> Dict[str, Any]:
+    """
+    Handle GET /drafts/{date} endpoint.
+
+    Args:
+        date: Date string in YYYY-MM-DD format
+
+    Returns:
+        Response with draft details
+    """
+    try:
+        # Validate date format
+        try:
+            datetime.strptime(date, "%Y-%m-%d")
+        except ValueError:
+            return {"error": "Invalid date format. Use YYYY-MM-DD"}, 400
+
+        # Get metadata (required)
+        metadata = get_draft_metadata(date)
+        if not metadata:
+            return {"error": f"Draft not found for date {date}"}, 404
+
+        # Get all draft files
+        result = {
+            "date": date,
+            "metadata": metadata,
+            "original": get_draft_file(date, "original.md") or "",
+            "references": get_draft_file(date, "references.md") or "",
+            "ideas": get_draft_file(date, "ideas.md") or "",
+            "goals": get_draft_file(date, "goals.md") or "",
+        }
+
+        return result
+
+    except ClientError as e:
+        logger.error(f"Error getting draft detail for {date}: {e}")
+        return {"error": "Internal server error"}, 500
+
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+        return {"error": "Internal server error"}, 500
+
+
+@logger.inject_lambda_context(correlation_id_path=API_GATEWAY_REST)
+def handler(event: dict, context: LambdaContext) -> dict:
+    """
+    Lambda handler for drafts API.
+
+    Args:
+        event: API Gateway event
+        context: Lambda context
+
+    Returns:
+        API Gateway response
+    """
+    return app.resolve(event, context)

--- a/infra-cdk/lambdas/drafts/requirements.txt
+++ b/infra-cdk/lambdas/drafts/requirements.txt
@@ -1,0 +1,2 @@
+aws-lambda-powertools>=3.0.0
+boto3>=1.34.0

--- a/infra-cdk/lib/backend-stack.ts
+++ b/infra-cdk/lib/backend-stack.ts
@@ -508,7 +508,7 @@ export class BackendStack extends cdk.NestedStack {
       description: "API for user feedback and future endpoints",
       defaultCorsPreflightOptions: {
         allowOrigins: [frontendUrl, "http://localhost:3000"],
-        allowMethods: ["POST", "OPTIONS"],
+        allowMethods: ["GET", "POST", "OPTIONS"],
         allowHeaders: ["Content-Type", "Authorization"],
       },
       deployOptions: {
@@ -563,6 +563,62 @@ export class BackendStack extends cdk.NestedStack {
       parameterName: `/${config.stack_name_base}/feedback-api-url`,
       stringValue: api.url,
       description: "Feedback API Gateway URL",
+    })
+
+    // Add Drafts API endpoints to the same API Gateway
+    this.createDraftsApiEndpoints(config, frontendUrl, api, authorizer)
+  }
+
+  private createDraftsApiEndpoints(
+    config: AppConfig,
+    frontendUrl: string,
+    api: apigateway.RestApi,
+    authorizer: apigateway.CognitoUserPoolsAuthorizer
+  ): void {
+    // Create Drafts Lambda function
+    const draftsLambda = new PythonFunction(this, "DraftsLambda", {
+      functionName: `${config.stack_name_base}-drafts`,
+      runtime: lambda.Runtime.PYTHON_3_13,
+      entry: path.join(__dirname, "..", "lambdas", "drafts"),
+      handler: "handler",
+      environment: {
+        S3_BUCKET_NAME: this.insightsBucket.bucketName,
+        CORS_ALLOWED_ORIGINS: `${frontendUrl},http://localhost:3000`,
+      },
+      timeout: cdk.Duration.seconds(30),
+      layers: [
+        lambda.LayerVersion.fromLayerVersionArn(
+          this,
+          "DraftsPowertoolsLayer",
+          `arn:aws:lambda:${
+            cdk.Stack.of(this).region
+          }:017000801446:layer:AWSLambdaPowertoolsPythonV3-python313-arm64:18`
+        ),
+      ],
+      logGroup: new logs.LogGroup(this, "DraftsLambdaLogGroup", {
+        logGroupName: `/aws/lambda/${config.stack_name_base}-drafts`,
+        retention: logs.RetentionDays.ONE_WEEK,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      }),
+    })
+
+    // Grant S3 read permissions for draft/ prefix
+    this.insightsBucket.grantRead(draftsLambda)
+
+    // Create /drafts resource
+    const draftsResource = api.root.addResource("drafts")
+
+    // GET /drafts - List all drafts
+    draftsResource.addMethod("GET", new apigateway.LambdaIntegration(draftsLambda), {
+      authorizer,
+      authorizationType: apigateway.AuthorizationType.COGNITO,
+    })
+
+    // GET /drafts/{date} - Get draft detail
+    const draftDetailResource = draftsResource.addResource("{date}")
+    draftDetailResource.addMethod("GET", new apigateway.LambdaIntegration(draftsLambda), {
+      authorizer,
+      authorizationType: apigateway.AuthorizationType.COGNITO,
     })
   }
 


### PR DESCRIPTION
## 概要
Phase 4の実装: 日記抽出結果（draft/）を閲覧するためのUIを追加しました。

Closes #9

## 実装内容

### バックエンド
- **Drafts Lambda関数**: S3のdraft/からデータ取得
  - `GET /drafts`: draft一覧取得（日付フィルタ対応）
  - `GET /drafts/{date}`: 特定日付の詳細取得
- **API Gateway**: 既存RestApiに/draftsリソース追加（Cognito認証）
- **IAM権限**: S3読み取り権限付与

### フロントエンド
- **DraftsPage**: 2カラムレイアウト（一覧 + 詳細）
- **DraftsList**: 左側に日付一覧表示
- **DraftDetail**: 右側にタブ形式で表示
  - Original Diary / References / Ideas / Goals
- **グローバルナビゲーション**: Chat / Drafts 切り替え
- **shadcn/ui Tabs**: タブコンポーネント追加

## テスト結果
- ✅ バックエンドデプロイ成功
- ✅ フロントエンドデプロイ成功
- ✅ 統合テスト完了（4件のdraft表示確認）
- ✅ タブ切り替え動作確認
- ✅ Markdownレンダリング確認